### PR TITLE
Expose lesson metadata in timetable cards

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -12,8 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.app || sudo xcode-select -s /Applications/Xcode.app
+      - name: Select Xcode 16 (26.x)
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.0.app \
+            || sudo xcode-select -s /Applications/Xcode_16.1.app \
+            || sudo xcode-select -s /Applications/Xcode.app
 
       - name: Resolve Swift packages
         run: |
@@ -27,7 +30,7 @@ jobs:
             -project BetterUntis.xcodeproj \
             -scheme BetterUntis \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 15,OS=18.0' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             clean test | tee xcodebuild.log
         env:
           NSUnbufferedIO: "YES"

--- a/BetterUntis/BetterUntis.xcdatamodeld/BetterUntis.xcdatamodel/contents
+++ b/BetterUntis/BetterUntis.xcdatamodeld/BetterUntis.xcdatamodel/contents
@@ -6,12 +6,27 @@
         <attribute name="foreColor" optional="YES" attributeType="String"/>
         <attribute name="id" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="infoText" optional="YES" attributeType="String"/>
+        <attribute name="periodData" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
         <attribute name="innerBackColor" optional="YES" attributeType="String"/>
         <attribute name="innerForeColor" optional="YES" attributeType="String"/>
         <attribute name="lessonId" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="lessonText" optional="YES" attributeType="String"/>
         <attribute name="startDateTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="substitutionText" optional="YES" attributeType="String"/>
+        <attribute name="userId" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="MasterDataEntity" representedClassName="MasterDataEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="alternateName" optional="YES" attributeType="String"/>
+        <attribute name="building" optional="YES" attributeType="String"/>
+        <attribute name="backColor" optional="YES" attributeType="String"/>
+        <attribute name="active" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="canViewTimetable" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="foreColor" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="longName" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="NO" attributeType="String"/>
+        <attribute name="type" optional="NO" attributeType="String"/>
         <attribute name="userId" optional="NO" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="UserEntity" representedClassName="UserEntity" syncable="YES" codeGenerationType="category">

--- a/BetterUntis/BetterUntisApp.swift
+++ b/BetterUntis/BetterUntisApp.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import CoreData
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @main
 struct BetterUntisApp: App {

--- a/BetterUntis/Models/CoreData/PersistenceController.swift
+++ b/BetterUntis/Models/CoreData/PersistenceController.swift
@@ -183,6 +183,12 @@ extension PersistenceController {
         infoTextAttribute.attributeType = .stringAttributeType
         infoTextAttribute.isOptional = true
 
+        let periodDataAttribute = NSAttributeDescription()
+        periodDataAttribute.name = "periodData"
+        periodDataAttribute.attributeType = .binaryDataAttributeType
+        periodDataAttribute.allowsExternalBinaryDataStorage = true
+        periodDataAttribute.isOptional = true
+
         let userIdForeignKey = NSAttributeDescription()
         userIdForeignKey.name = "userId"
         userIdForeignKey.attributeType = .integer64AttributeType
@@ -200,10 +206,91 @@ extension PersistenceController {
             lessonTextAttribute,
             substitutionTextAttribute,
             infoTextAttribute,
+            periodDataAttribute,
             userIdForeignKey
         ]
 
-        model.entities = [userEntity, periodEntity]
+        // Master Data Entity (generic storage for rooms, teachers, subjects, classes)
+        let masterDataEntity = NSEntityDescription()
+        masterDataEntity.name = "MasterDataEntity"
+        masterDataEntity.managedObjectClassName = "MasterDataEntity"
+
+        let masterIdAttribute = NSAttributeDescription()
+        masterIdAttribute.name = "id"
+        masterIdAttribute.attributeType = .integer64AttributeType
+        masterIdAttribute.isOptional = false
+
+        let masterTypeAttribute = NSAttributeDescription()
+        masterTypeAttribute.name = "type"
+        masterTypeAttribute.attributeType = .stringAttributeType
+        masterTypeAttribute.isOptional = false
+
+        let masterNameAttribute = NSAttributeDescription()
+        masterNameAttribute.name = "name"
+        masterNameAttribute.attributeType = .stringAttributeType
+        masterNameAttribute.isOptional = false
+
+        let masterLongNameAttribute = NSAttributeDescription()
+        masterLongNameAttribute.name = "longName"
+        masterLongNameAttribute.attributeType = .stringAttributeType
+        masterLongNameAttribute.isOptional = true
+
+        let masterDisplayNameAttribute = NSAttributeDescription()
+        masterDisplayNameAttribute.name = "displayName"
+        masterDisplayNameAttribute.attributeType = .stringAttributeType
+        masterDisplayNameAttribute.isOptional = true
+
+        let masterAlternateNameAttribute = NSAttributeDescription()
+        masterAlternateNameAttribute.name = "alternateName"
+        masterAlternateNameAttribute.attributeType = .stringAttributeType
+        masterAlternateNameAttribute.isOptional = true
+
+        let masterBuildingAttribute = NSAttributeDescription()
+        masterBuildingAttribute.name = "building"
+        masterBuildingAttribute.attributeType = .stringAttributeType
+        masterBuildingAttribute.isOptional = true
+
+        let masterForeColorAttribute = NSAttributeDescription()
+        masterForeColorAttribute.name = "foreColor"
+        masterForeColorAttribute.attributeType = .stringAttributeType
+        masterForeColorAttribute.isOptional = true
+
+        let masterBackColorAttribute = NSAttributeDescription()
+        masterBackColorAttribute.name = "backColor"
+        masterBackColorAttribute.attributeType = .stringAttributeType
+        masterBackColorAttribute.isOptional = true
+
+        let masterActiveAttribute = NSAttributeDescription()
+        masterActiveAttribute.name = "active"
+        masterActiveAttribute.attributeType = .booleanAttributeType
+        masterActiveAttribute.isOptional = true
+
+        let masterCanViewAttribute = NSAttributeDescription()
+        masterCanViewAttribute.name = "canViewTimetable"
+        masterCanViewAttribute.attributeType = .booleanAttributeType
+        masterCanViewAttribute.isOptional = true
+
+        let masterUserIdAttribute = NSAttributeDescription()
+        masterUserIdAttribute.name = "userId"
+        masterUserIdAttribute.attributeType = .integer64AttributeType
+        masterUserIdAttribute.isOptional = false
+
+        masterDataEntity.properties = [
+            masterIdAttribute,
+            masterTypeAttribute,
+            masterNameAttribute,
+            masterLongNameAttribute,
+            masterDisplayNameAttribute,
+            masterAlternateNameAttribute,
+            masterBuildingAttribute,
+            masterForeColorAttribute,
+            masterBackColorAttribute,
+            masterActiveAttribute,
+            masterCanViewAttribute,
+            masterUserIdAttribute
+        ]
+
+        model.entities = [userEntity, periodEntity, masterDataEntity]
 
         return model
     }

--- a/BetterUntis/Repositories/TimetableRepository.swift
+++ b/BetterUntis/Repositories/TimetableRepository.swift
@@ -27,18 +27,17 @@ class TimetableRepository: ObservableObject {
             isLoading = false
         }
 
-        // Try to load from cache first if not forcing refresh
-        // TEMPORARILY DISABLED FOR DEBUGGING - always force refresh to see live data
-        /*
-        if !forceRefresh, let cachedTimetable = loadCachedTimetable(for: user, startDate: startDate, endDate: endDate) {
+        // Try to load from cache first unless forced to refresh
+        if !forceRefresh,
+           let cachedTimetable = loadCachedTimetable(for: user, startDate: startDate, endDate: endDate) {
             await MainActor.run {
                 self.currentTimetable = cachedTimetable
                 self.lastUpdated = Date()
             }
+            DebugLogger.logDataCacheHit(type: "Timetable")
             return
         }
-        */
-        print("📊 Forcing live data refresh for debugging")
+        DebugLogger.logDataCacheMiss(type: "Timetable")
 
         // Load from API
         guard let credentials = keychainManager.loadUserCredentials(userId: String(user.id)) else {
@@ -97,13 +96,16 @@ class TimetableRepository: ObservableObject {
 
             // Extract and store master data (including rooms) if present
             if let masterData = result["masterData"] as? [String: Any] {
-                print("📊 Master data found but Core Data model needs RoomEntity - skipping storage for now")
-                // TODO: Add RoomEntity to Core Data model, then re-enable this:
-                // try storeMasterData(masterData, for: user)
+                try storeMasterData(masterData, for: user)
             }
 
             // Parse timetable from dictionary
-            let timetable = try parseTimetableFromDict(result, startDate: startDate, endDate: endDate)
+            let timetable = try parseTimetableFromDict(
+                result,
+                user: user,
+                startDate: startDate,
+                endDate: endDate
+            )
 
             // Cache the timetable
             try cacheTimetable(timetable, for: user)
@@ -278,7 +280,7 @@ class TimetableRepository: ObservableObject {
         return normalized
     }
 
-    private func parseTimetableFromDict(_ dict: [String: Any], startDate: Date, endDate: Date) throws -> Timetable {
+    private func parseTimetableFromDict(_ dict: [String: Any], user: User, startDate: Date, endDate: Date) throws -> Timetable {
         print("📊 Parsing timetable dictionary with keys: \(Array(dict.keys))")
 
         // Check for server compatibility message
@@ -288,7 +290,19 @@ class TimetableRepository: ObservableObject {
         }
 
         // Prepare master data lookup for element resolution
-        let masterDataIndex = buildMasterDataIndex(from: dict["masterData"] as? [String: Any])
+        var masterDataIndex = buildMasterDataIndex(
+            from: dict["masterData"] as? [String: Any],
+            userId: user.id
+        )
+        if let storedIndex = loadStoredMasterData(for: user.id) {
+            if var index = masterDataIndex {
+                var mutableIndex = index
+                mutableIndex.mergeMissing(from: storedIndex)
+                masterDataIndex = mutableIndex
+            } else {
+                masterDataIndex = storedIndex
+            }
+        }
 
         // Try different possible data structures
         var periodsArray: [[String: Any]]?
@@ -412,14 +426,46 @@ class TimetableRepository: ObservableObject {
                                         second: 0,
                                         of: baseDate) ?? baseDate
 
-        let subjects = periodElements(from: dict["su"], type: .subject, masterData: masterData)
-        let teachers = periodElements(from: dict["te"], type: .teacher, masterData: masterData)
-        let classes = periodElements(from: dict["kl"], type: .klasse, masterData: masterData)
-        let rooms = periodElements(from: dict["ro"], type: .room, masterData: masterData)
-        let allElements = classes + teachers + subjects + rooms
+        let fallbackElements = parseGenericElements(from: dict["elements"], masterData: masterData)
 
-        let lessonTextValue = lessonTitle(subjectElements: subjects, periodDict: dict)
-        let infoText = trimmed(dict["info"] as? String)
+        var subjects = periodElements(from: dict["su"], type: .subject, masterData: masterData)
+        var teachers = periodElements(from: dict["te"], type: .teacher, masterData: masterData)
+        var classes = periodElements(from: dict["kl"], type: .klasse, masterData: masterData)
+        var rooms = periodElements(from: dict["ro"], type: .room, masterData: masterData)
+
+        if subjects.isEmpty {
+            subjects = fallbackElements.filter { $0.type == .subject }
+        }
+        if teachers.isEmpty {
+            teachers = fallbackElements.filter { $0.type == .teacher }
+        }
+        if classes.isEmpty {
+            classes = fallbackElements.filter { $0.type == .klasse }
+        }
+        if rooms.isEmpty {
+            rooms = fallbackElements.filter { $0.type == .room }
+        }
+
+        let allElements = mergeElements(classes, teachers, subjects, rooms)
+
+        let lessonTextValue = trimmed(dict["lessonText"] as? String)
+            ?? lessonTitle(subjectElements: subjects, periodDict: dict)
+            ?? trimmed(dict["text"] as? String)
+
+        let substitutionText = trimmed(dict["substitutionText"] as? String
+            ?? dict["lstext"] as? String
+            ?? dict["substitution"] as? String)
+
+        let infoText = infoValue(from: dict)
+
+        let rights = parsePeriodRights(from: dict["can"])
+        let states = parsePeriodStates(from: dict["is"], code: dict["code"], flags: dict["statflags"], dict: dict)
+        let homeWorks = parseHomeworks(from: dict["homeWorks"])
+        let exam = parseExam(from: dict)
+        let messengerChannel = parseMessengerChannel(from: dict["messengerChannel"]) ??
+            parseMessengerChannel(from: dict["messengerChannelInfo"])
+        let onlineLink = dict["onlinePeriodLink"] as? String ?? dict["onlineLessonLink"] as? String
+        let isOnlinePeriod = (dict["isOnlinePeriod"] as? Bool) ?? (onlineLink != nil)
 
         return Period(
             id: id,
@@ -432,17 +478,17 @@ class TimetableRepository: ObservableObject {
             innerBackColor: dict["innerBackColor"] as? String ?? "#FFFFFF",
             text: PeriodText(
                 lesson: lessonTextValue,
-                substitution: nil,
+                substitution: substitutionText,
                 info: infoText
             ),
             elements: allElements,
-            can: [],
-            is: [],
-            homeWorks: nil,
-            exam: nil,
-            isOnlinePeriod: dict["isOnlinePeriod"] as? Bool,
-            messengerChannel: nil,
-            onlinePeriodLink: dict["onlinePeriodLink"] as? String,
+            can: rights,
+            is: states,
+            homeWorks: homeWorks,
+            exam: exam,
+            isOnlinePeriod: isOnlinePeriod,
+            messengerChannel: messengerChannel,
+            onlinePeriodLink: onlineLink,
             blockHash: dict["blockHash"] as? Int
         )
     }
@@ -499,19 +545,46 @@ class TimetableRepository: ObservableObject {
             }
         }
 
-        let subjects = periodElements(from: dict["su"], type: .subject, masterData: masterData)
-        let teachers = periodElements(from: dict["te"], type: .teacher, masterData: masterData)
-        let classes = periodElements(from: dict["kl"], type: .klasse, masterData: masterData)
-        let rooms = periodElements(from: dict["ro"], type: .room, masterData: masterData)
-        let allElements = classes + teachers + subjects + rooms
+        let fallbackElements = parseGenericElements(from: dict["elements"], masterData: masterData)
 
-        var lessonTextValue = lessonTitle(subjectElements: subjects, periodDict: dict) ?? "Course \(index + 1)"
+        var subjects = periodElements(from: dict["su"], type: .subject, masterData: masterData)
+        var teachers = periodElements(from: dict["te"], type: .teacher, masterData: masterData)
+        var classes = periodElements(from: dict["kl"], type: .klasse, masterData: masterData)
+        var rooms = periodElements(from: dict["ro"], type: .room, masterData: masterData)
+
+        if subjects.isEmpty {
+            subjects = fallbackElements.filter { $0.type == .subject }
+        }
+        if teachers.isEmpty {
+            teachers = fallbackElements.filter { $0.type == .teacher }
+        }
+        if classes.isEmpty {
+            classes = fallbackElements.filter { $0.type == .klasse }
+        }
+        if rooms.isEmpty {
+            rooms = fallbackElements.filter { $0.type == .room }
+        }
+
+        let allElements = mergeElements(classes, teachers, subjects, rooms)
+
+        var lessonTextValue = trimmed(dict["lessonText"] as? String)
+            ?? lessonTitle(subjectElements: subjects, periodDict: dict)
+            ?? "Course \(index + 1)"
 
         if let hpw = intValue(from: dict["hpw"]), hpw > 0 {
             lessonTextValue += " (\(hpw)h/week)"
         }
 
-        let info = trimmed(dict["info"] as? String)
+        let info = infoValue(from: dict)
+        let substitutionText = trimmed(dict["substitutionText"] as? String ?? dict["lstext"] as? String)
+        let rights = parsePeriodRights(from: dict["can"])
+        let states = parsePeriodStates(from: dict["is"], code: dict["code"], flags: dict["statflags"], dict: dict)
+        let homeWorks = parseHomeworks(from: dict["homeWorks"])
+        let exam = parseExam(from: dict)
+        let messengerChannel = parseMessengerChannel(from: dict["messengerChannel"]) ??
+            parseMessengerChannel(from: dict["messengerChannelInfo"])
+        let onlineLink = dict["onlinePeriodLink"] as? String ?? dict["onlineLessonLink"] as? String
+        let isOnlinePeriod = (dict["isOnlinePeriod"] as? Bool) ?? (onlineLink != nil)
 
         print("📊 Creating basic period: id=\(id), lesson=\(lessonTextValue), start=\(startDateTime), end=\(endDateTime)")
 
@@ -526,17 +599,17 @@ class TimetableRepository: ObservableObject {
             innerBackColor: dict["innerBackColor"] as? String ?? "#FFFFFF",
             text: PeriodText(
                 lesson: lessonTextValue,
-                substitution: nil,
+                substitution: substitutionText,
                 info: info
             ),
             elements: allElements,
-            can: [],
-            is: [],
-            homeWorks: nil,
-            exam: nil,
-            isOnlinePeriod: dict["isOnlinePeriod"] as? Bool,
-            messengerChannel: nil,
-            onlinePeriodLink: dict["onlinePeriodLink"] as? String,
+            can: rights,
+            is: states,
+            homeWorks: homeWorks,
+            exam: exam,
+            isOnlinePeriod: isOnlinePeriod,
+            messengerChannel: messengerChannel,
+            onlinePeriodLink: onlineLink,
             blockHash: dict["blockHash"] as? Int
         )
     }
@@ -631,6 +704,24 @@ class TimetableRepository: ObservableObject {
         return nil
     }
 
+    private func infoValue(from dict: [String: Any]) -> String? {
+        let candidates: [Any?] = [
+            dict["info"],
+            dict["activityType"],
+            dict["lstext"],
+            dict["notice"],
+            dict["message"],
+            dict["stateText"]
+        ]
+
+        for value in candidates {
+            if let string = trimmed(value as? String), !string.isEmpty {
+                return string
+            }
+        }
+        return nil
+    }
+
     private func periodElements(
         from rawValue: Any?,
         type: ElementType,
@@ -659,6 +750,50 @@ class TimetableRepository: ObservableObject {
             let entry = masterData?.entry(for: type, id: id)
             return makePeriodElement(id: id, type: type, dict: nil, masterEntry: entry)
         }
+    }
+
+    private func parseGenericElements(from rawValue: Any?, masterData: MasterDataIndex?) -> [PeriodElement] {
+        guard let array = rawValue as? [[String: Any]], !array.isEmpty else { return [] }
+        var elements: [PeriodElement] = []
+
+        for dict in array {
+            let elementType: ElementType?
+            if let rawType = dict["type"] as? Int {
+                elementType = ElementType(rawValue: rawType)
+            } else if let rawTypeString = dict["type"] as? String {
+                if let numeric = Int(rawTypeString) {
+                    elementType = ElementType(rawValue: numeric)
+                } else {
+                    elementType = ElementType(restType: rawTypeString)
+                }
+            } else {
+                elementType = nil
+            }
+
+            guard let type = elementType,
+                  let id = int64(from: dict["id"]) else { continue }
+
+            let entry = masterData?.entry(for: type, id: id)
+            elements.append(makePeriodElement(id: id, type: type, dict: dict, masterEntry: entry))
+        }
+
+        return elements
+    }
+
+    private func mergeElements(_ groups: [PeriodElement]...) -> [PeriodElement] {
+        var seen = Set<String>()
+        var result: [PeriodElement] = []
+
+        for group in groups {
+            for element in group {
+                let key = "\(element.type.rawValue)-\(element.id)"
+                if seen.insert(key).inserted {
+                    result.append(element)
+                }
+            }
+        }
+
+        return result
     }
 
     private func makePeriodElement(
@@ -696,35 +831,46 @@ class TimetableRepository: ObservableObject {
         )
     }
 
-    private func buildMasterDataIndex(from masterDataDict: [String: Any]?) -> MasterDataIndex? {
-        guard let masterDataDict else { return nil }
+    private func buildMasterDataIndex(from masterDataDict: [String: Any]?, userId: Int64) -> MasterDataIndex? {
         var index = MasterDataIndex()
 
-        if let classes = masterDataDict["klassen"] as? [[String: Any]] {
-            for klass in classes {
-                guard let entry = parseMasterDataEntry(type: .klasse, data: klass) else { continue }
-                index.classes[entry.id] = entry
+        if let masterDataDict {
+            if let classes = masterDataDict["klassen"] as? [[String: Any]] {
+                for klass in classes {
+                    guard let entry = parseMasterDataEntry(type: .klasse, data: klass) else { continue }
+                    index.classes[entry.id] = entry
+                }
+            }
+
+            if let teachers = masterDataDict["teachers"] as? [[String: Any]] {
+                for teacher in teachers {
+                    guard let entry = parseMasterDataEntry(type: .teacher, data: teacher) else { continue }
+                    index.teachers[entry.id] = entry
+                }
+            }
+
+            if let subjects = masterDataDict["subjects"] as? [[String: Any]] {
+                for subject in subjects {
+                    guard let entry = parseMasterDataEntry(type: .subject, data: subject) else { continue }
+                    index.subjects[entry.id] = entry
+                }
+            }
+
+            if let rooms = masterDataDict["rooms"] as? [[String: Any]] {
+                for room in rooms {
+                    guard let entry = parseMasterDataEntry(type: .room, data: room) else { continue }
+                    index.rooms[entry.id] = entry
+                }
             }
         }
 
-        if let teachers = masterDataDict["teachers"] as? [[String: Any]] {
-            for teacher in teachers {
-                guard let entry = parseMasterDataEntry(type: .teacher, data: teacher) else { continue }
-                index.teachers[entry.id] = entry
-            }
-        }
-
-        if let subjects = masterDataDict["subjects"] as? [[String: Any]] {
-            for subject in subjects {
-                guard let entry = parseMasterDataEntry(type: .subject, data: subject) else { continue }
-                index.subjects[entry.id] = entry
-            }
-        }
-
-        if let rooms = masterDataDict["rooms"] as? [[String: Any]] {
-            for room in rooms {
-                guard let entry = parseMasterDataEntry(type: .room, data: room) else { continue }
-                index.rooms[entry.id] = entry
+        if let stored = loadStoredMasterData(for: userId) {
+            if index.isEmpty {
+                return stored
+            } else {
+                var mutableIndex = index
+                mutableIndex.mergeMissing(from: stored)
+                return mutableIndex
             }
         }
 
@@ -759,6 +905,20 @@ class TimetableRepository: ObservableObject {
         let backColor = stringValue(from: data["backColor"])
         let canViewTimetable = data["canViewTimetable"] as? Bool
 
+        let isActive: Bool?
+        if let active = data["active"] as? Bool {
+            isActive = active
+        } else if let activeNumber = data["active"] as? NSNumber {
+            isActive = activeNumber.boolValue
+        } else {
+            isActive = nil
+        }
+
+        var building: String? = nil
+        if type == .room {
+            building = trimmed(data["building"] as? String)
+        }
+
         return MasterDataEntry(
             id: id,
             name: name,
@@ -767,8 +927,183 @@ class TimetableRepository: ObservableObject {
             alternateName: shortName,
             foreColor: foreColor,
             backColor: backColor,
-            canViewTimetable: canViewTimetable
+            isActive: isActive,
+            canViewTimetable: canViewTimetable,
+            building: building
         )
+    }
+
+    private func parsePeriodRights(from value: Any?) -> [PeriodRight] {
+        let rawValues = extractStringArray(from: value)
+        var rights: [PeriodRight] = []
+        for raw in rawValues {
+            let normalized = raw.uppercased()
+            if let right = PeriodRight(rawValue: normalized) {
+                rights.append(right)
+            }
+        }
+        return rights
+    }
+
+    private func parsePeriodStates(from value: Any?, code: Any?, flags: Any?, dict: [String: Any]) -> [PeriodState] {
+        var states: [PeriodState] = []
+        let rawValues = extractStringArray(from: value)
+
+        func appendState(_ candidate: PeriodState) {
+            if !states.contains(candidate) {
+                states.append(candidate)
+            }
+        }
+
+        for raw in rawValues {
+            if let mapped = mapStateString(raw) {
+                appendState(mapped)
+            }
+        }
+
+        if let codeString = (code as? String) ?? (code as? NSNumber)?.stringValue,
+           let mapped = mapStateString(codeString) {
+            appendState(mapped)
+        }
+
+        if let flagString = flags as? String {
+            for part in flagString.split(separator: ",") {
+                if let mapped = mapStateString(String(part)) {
+                    appendState(mapped)
+                }
+            }
+        }
+
+        if let substitution = dict["substitutionText"] as? String,
+           !substitution.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            appendState(.teacherSubstitution)
+        }
+
+        return states
+    }
+
+    private func mapStateString(_ raw: String) -> PeriodState? {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+        if let exact = PeriodState(rawValue: normalized) {
+            return exact
+        }
+
+        switch normalized {
+        case "CANCELED": return .cancelled
+        case "ROOM_SUBSTITUTION": return .roomSubstitution
+        case "ROOM SUBSTITUTE": return .roomSubstitution
+        case "TEACHER_SUBSTITUTION": return .teacherSubstitution
+        case "TEACHER SUBSTITUTE": return .teacherSubstitution
+        case "SUBSTITUTION": return .teacherSubstitution
+        case "SUBSTITUTES": return .teacherSubstitution
+        case "SUBJECT_SUBSTITUTION": return .subjectSubstitution
+        case "ROOM": return .roomSubstitution
+        case "TEACHER": return .teacherSubstitution
+        default: return nil
+        }
+    }
+
+    private func extractStringArray(from value: Any?) -> [String] {
+        if let strings = value as? [String] { return strings }
+        if let array = value as? [Any] {
+            return array.compactMap { element in
+                if let str = element as? String { return str }
+                if let number = element as? NSNumber { return number.stringValue }
+                return nil
+            }
+        }
+        if let string = value as? String {
+            if string.contains(",") {
+                return string.split(separator: ",").map { String($0) }
+            }
+            return [string]
+        }
+        return []
+    }
+
+    private func parseHomeworks(from value: Any?) -> [PeriodHomeWork]? {
+        guard let array = value as? [[String: Any]], !array.isEmpty else { return nil }
+        var homeworks: [PeriodHomeWork] = []
+
+        for entry in array {
+            let identifier = int64(from: entry["id"]) ?? int64(from: entry["homeworkId"]) ?? int64(from: entry["lessonId"])
+            guard let id = identifier else { continue }
+            let lessonId = int64(from: entry["lessonId"]) ?? id
+            let assignedDate = parseDateValue(entry["date"]) ?? Date()
+            let dueDate = parseDateValue(entry["dueDate"]) ?? assignedDate
+            let text = trimmed(entry["text"] as? String ?? entry["description"] as? String) ?? "Homework"
+            let remark = trimmed(entry["remark"] as? String ?? entry["additionalText"] as? String)
+            let completed = (entry["completed"] as? Bool) ?? (entry["done"] as? Bool) ?? false
+
+            homeworks.append(
+                PeriodHomeWork(
+                    id: id,
+                    lessonId: lessonId,
+                    date: assignedDate,
+                    dueDate: dueDate,
+                    text: text,
+                    remark: remark,
+                    completed: completed
+                )
+            )
+        }
+
+        return homeworks.isEmpty ? nil : homeworks
+    }
+
+    private func parseExam(from dict: [String: Any]) -> PeriodExam? {
+        guard let examDict = dict["exam"] as? [String: Any] else { return nil }
+
+        if examDict.isEmpty {
+            return nil
+        }
+
+        let id = int64(from: examDict["id"])
+        let type = trimmed(examDict["examType"] as? String ?? examDict["type"] as? String)
+        let name = trimmed(examDict["name"] as? String)
+        let text = trimmed(examDict["text"] as? String ?? examDict["description"] as? String)
+
+        if id == nil, type == nil, name == nil, text == nil {
+            return nil
+        }
+
+        return PeriodExam(id: id, examType: type, name: name, text: text)
+    }
+
+    private func parseMessengerChannel(from value: Any?) -> MessengerChannel? {
+        guard let dict = value as? [String: Any] else { return nil }
+        guard let idString = dict["id"] as? String ?? (dict["id"] as? NSNumber)?.stringValue else { return nil }
+        let name = trimmed(dict["name"] as? String ?? dict["displayName"] as? String) ?? "Channel"
+        return MessengerChannel(id: idString, name: name)
+    }
+
+    private func parseDateValue(_ value: Any?) -> Date? {
+        if let date = value as? Date { return date }
+        if let string = value as? String {
+            if let iso = ISO8601DateFormatter().date(from: string) {
+                return iso
+            }
+            if let normalized = normalizedDateString(from: string) {
+                return dateFromYYYYMMDD(normalized)
+            }
+        }
+        if let number = value as? NSNumber {
+            let padded = String(format: "%08lld", number.int64Value)
+            return dateFromYYYYMMDD(padded)
+        }
+        if let intValue = value as? Int {
+            let padded = String(format: "%08d", intValue)
+            return dateFromYYYYMMDD(padded)
+        }
+        return nil
+    }
+
+    private func dateFromYYYYMMDD(_ string: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.date(from: string)
     }
 
     private func stringValue(from value: Any?) -> String? {
@@ -824,93 +1159,144 @@ class TimetableRepository: ObservableObject {
             .min(by: { $0.startDateTime < $1.startDateTime })
     }
 
-    // MARK: - Master Data Storage
+    
+    private func loadStoredMasterData(for userId: Int64) -> MasterDataIndex? {
+        let context = persistenceController.container.viewContext
+        let request: NSFetchRequest<NSManagedObject> = NSFetchRequest(entityName: "MasterDataEntity")
+        request.predicate = NSPredicate(format: "userId == %lld", userId)
+
+        do {
+            let items = try context.fetch(request)
+            if items.isEmpty {
+                return nil
+            }
+
+            var index = MasterDataIndex()
+            for item in items {
+                guard let type = item.value(forKey: "type") as? String,
+                      let id = item.value(forKey: "id") as? Int64,
+                      let name = item.value(forKey: "name") as? String else { continue }
+
+                let entry = MasterDataEntry(
+                    id: id,
+                    name: name,
+                    longName: item.value(forKey: "longName") as? String,
+                    displayName: item.value(forKey: "displayName") as? String,
+                    alternateName: item.value(forKey: "alternateName") as? String,
+                    foreColor: item.value(forKey: "foreColor") as? String,
+                    backColor: item.value(forKey: "backColor") as? String,
+                    isActive: item.value(forKey: "active") as? Bool,
+                    canViewTimetable: item.value(forKey: "canViewTimetable") as? Bool,
+                    building: item.value(forKey: "building") as? String
+                )
+
+                switch type {
+                case storageKey(for: .klasse): index.classes[id] = entry
+                case storageKey(for: .teacher): index.teachers[id] = entry
+                case storageKey(for: .subject): index.subjects[id] = entry
+                case storageKey(for: .room): index.rooms[id] = entry
+                default: continue
+                }
+            }
+            return index
+        } catch {
+            print("⚠️ Failed to load stored master data: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func storageKey(for type: ElementType) -> String {
+        switch type {
+        case .klasse: return "klasse"
+        case .teacher: return "teacher"
+        case .subject: return "subject"
+        case .room: return "room"
+        case .student: return "student"
+        }
+    }
+
+// MARK: - Master Data Storage
 
     private func storeMasterData(_ masterDataDict: [String: Any], for user: User) throws {
-        print("🔄 Storing master data for user \(user.id)")
+        let context = persistenceController.container.viewContext
 
-        // Extract rooms from master data
-        if let roomsArray = masterDataDict["rooms"] as? [[String: Any]] {
-            print("📊 Found \(roomsArray.count) rooms in master data")
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "MasterDataEntity")
+        fetchRequest.predicate = NSPredicate(format: "userId == %lld", user.id)
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+        try context.execute(deleteRequest)
 
-            let context = persistenceController.container.viewContext
-
-            // Clear existing rooms for this user
-            let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "RoomEntity")
-            fetchRequest.predicate = NSPredicate(format: "userId == %lld", user.id)
-            let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-
-            do {
-                try context.execute(deleteRequest)
-                print("✅ Cleared existing rooms for user")
-            } catch {
-                print("⚠️ Failed to clear existing rooms: \(error.localizedDescription)")
-            }
-
-            // Store new rooms
-            for roomDict in roomsArray {
-                guard let roomId = roomDict["id"] as? Int64,
-                      let name = roomDict["name"] as? String else {
-                    continue
-                }
-
-                let roomEntity = NSEntityDescription.entity(forEntityName: "RoomEntity", in: context)!
-                let room = NSManagedObject(entity: roomEntity, insertInto: context)
-
-                room.setValue(roomId, forKey: "id")
-                room.setValue(name, forKey: "name")
-                room.setValue(roomDict["longName"] as? String ?? name, forKey: "longName")
-                room.setValue(roomDict["active"] as? Bool ?? true, forKey: "active")
-                room.setValue(roomDict["building"] as? String, forKey: "building")
-                room.setValue(user.id, forKey: "userId")
-            }
-
-            // Save the context
-            do {
-                try context.save()
-                print("✅ Successfully stored \(roomsArray.count) rooms")
-            } catch {
-                print("❌ Failed to save rooms: \(error.localizedDescription)")
-                throw TimetableError.cachingFailed
-            }
-        } else {
-            print("📊 No rooms found in master data")
+        guard let entity = NSEntityDescription.entity(forEntityName: "MasterDataEntity", in: context) else {
+            return
         }
 
-        // TODO: Store other master data entities (subjects, teachers, etc.) if needed
+        func store(_ entries: [[String: Any]], type: ElementType) {
+            for entry in entries {
+                guard let identifier = int64(from: entry["id"]) else { continue }
+
+                let object = NSManagedObject(entity: entity, insertInto: context)
+                object.setValue(identifier, forKey: "id")
+                object.setValue(storageKey(for: type), forKey: "type")
+                object.setValue(stringValue(from: entry["name"]) ?? "#\(identifier)", forKey: "name")
+                object.setValue(stringValue(from: entry["longName"] ?? entry["longname"]), forKey: "longName")
+                object.setValue(stringValue(from: entry["displayName"] ?? entry["displayname"]), forKey: "displayName")
+                object.setValue(stringValue(from: entry["shortName"] ?? entry["shortname"]), forKey: "alternateName")
+                if type == .room {
+                    object.setValue(stringValue(from: entry["building"]), forKey: "building")
+                }
+                object.setValue(stringValue(from: entry["foreColor"]), forKey: "foreColor")
+                object.setValue(stringValue(from: entry["backColor"]), forKey: "backColor")
+
+                if let active = entry["active"] as? Bool {
+                    object.setValue(active, forKey: "active")
+                } else if let activeNumber = entry["active"] as? NSNumber {
+                    object.setValue(activeNumber.boolValue, forKey: "active")
+                }
+
+                if let canView = entry["canViewTimetable"] as? Bool {
+                    object.setValue(canView, forKey: "canViewTimetable")
+                } else if let canViewNumber = entry["canViewTimetable"] as? NSNumber {
+                    object.setValue(canViewNumber.boolValue, forKey: "canViewTimetable")
+                }
+
+                object.setValue(user.id, forKey: "userId")
+            }
+        }
+
+        if let classes = masterDataDict["klassen"] as? [[String: Any]] {
+            store(classes, type: .klasse)
+        }
+        if let teachers = masterDataDict["teachers"] as? [[String: Any]] {
+            store(teachers, type: .teacher)
+        }
+        if let subjects = masterDataDict["subjects"] as? [[String: Any]] {
+            store(subjects, type: .subject)
+        }
+        if let rooms = masterDataDict["rooms"] as? [[String: Any]] {
+            store(rooms, type: .room)
+        }
+
+        if context.hasChanges {
+            try context.save()
+        }
     }
+
 
     // MARK: - Room Data Access
 
     func getRoomsFromMasterData(for user: User) -> [Room] {
-        let context = persistenceController.container.viewContext
-        let fetchRequest: NSFetchRequest<NSManagedObject> = NSFetchRequest(entityName: "RoomEntity")
-        fetchRequest.predicate = NSPredicate(format: "userId == %lld AND active == true", user.id)
-        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "name", ascending: true)]
-
-        do {
-            let roomEntities = try context.fetch(fetchRequest)
-            let rooms = roomEntities.compactMap { entity -> Room? in
-                guard let id = entity.value(forKey: "id") as? Int64,
-                      let name = entity.value(forKey: "name") as? String else {
-                    return nil
-                }
-
-                return Room(
-                    id: id,
-                    name: name,
-                    longName: entity.value(forKey: "longName") as? String ?? name,
-                    active: entity.value(forKey: "active") as? Bool ?? true,
-                    building: entity.value(forKey: "building") as? String
-                )
-            }
-
-            print("📊 Retrieved \(rooms.count) rooms from master data for user \(user.id)")
-            return rooms
-        } catch {
-            print("❌ Failed to fetch rooms from master data: \(error.localizedDescription)")
+        guard let index = loadStoredMasterData(for: user.id) else {
             return []
         }
+
+        return index.rooms.values.compactMap { entry in
+            Room(
+                id: entry.id,
+                name: entry.name,
+                longName: entry.longName ?? entry.name,
+                active: entry.isActive ?? true,
+                building: entry.building
+            )
+        }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 }
 
@@ -924,7 +1310,9 @@ private struct MasterDataEntry {
     let alternateName: String?
     let foreColor: String?
     let backColor: String?
+    let isActive: Bool?
     let canViewTimetable: Bool?
+    let building: String?
 }
 
 private struct MasterDataIndex {
@@ -950,6 +1338,21 @@ private struct MasterDataIndex {
 
     var isEmpty: Bool {
         classes.isEmpty && teachers.isEmpty && subjects.isEmpty && rooms.isEmpty
+    }
+
+    mutating func mergeMissing(from other: MasterDataIndex) {
+        for (id, entry) in other.classes where classes[id] == nil {
+            classes[id] = entry
+        }
+        for (id, entry) in other.teachers where teachers[id] == nil {
+            teachers[id] = entry
+        }
+        for (id, entry) in other.subjects where subjects[id] == nil {
+            subjects[id] = entry
+        }
+        for (id, entry) in other.rooms where rooms[id] == nil {
+            rooms[id] = entry
+        }
     }
 }
 
@@ -979,6 +1382,14 @@ enum TimetableError: Error, LocalizedError {
 // Core Data extensions for PeriodEntity - the entity class will be generated automatically
 extension PeriodEntity {
     func toDomainModel() -> Period {
+        if let data = self.periodData {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            if let decoded = try? decoder.decode(Period.self, from: data) {
+                return decoded
+            }
+        }
+
         return Period(
             id: self.id,
             lessonId: self.lessonId,
@@ -1018,5 +1429,11 @@ extension PeriodEntity {
         self.substitutionText = period.text.substitution
         self.infoText = period.text.info
         self.userId = userId
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        if let data = try? encoder.encode(period) {
+            self.periodData = data
+        }
     }
 }

--- a/BetterUntis/Repositories/UserRepository.swift
+++ b/BetterUntis/Repositories/UserRepository.swift
@@ -147,7 +147,7 @@ class UserRepository: ObservableObject {
                 print("✅ getUserData successful")
 
                 // Parse user data from dictionary
-                guard let userMasterId = userDataResult["masterId"] as? Int64,
+                guard let userMasterId = int64Value(from: userDataResult["masterId"]),
                       let userDisplayName = userDataResult["displayName"] as? String,
                       let userSchoolName = userDataResult["schoolName"] as? String else {
                     throw LoginError.invalidUserData
@@ -347,6 +347,22 @@ class UserRepository: ObservableObject {
 
     func getUserCredentials(for userId: Int64) -> UserCredentials? {
         return keychainManager.loadUserCredentials(userId: String(userId))
+    }
+
+    private func int64Value(from value: Any?) -> Int64? {
+        if let number = value as? NSNumber {
+            return number.int64Value
+        }
+        if let int64 = value as? Int64 {
+            return int64
+        }
+        if let int = value as? Int {
+            return Int64(int)
+        }
+        if let string = value as? String {
+            return Int64(string)
+        }
+        return nil
     }
 }
 

--- a/BetterUntis/Utilities/ErrorTracker.swift
+++ b/BetterUntis/Utilities/ErrorTracker.swift
@@ -1,5 +1,8 @@
 import Foundation
 import os.log
+#if canImport(Darwin)
+import Darwin
+#endif
 
 /// Error tracking and crash reporting system for debugging
 class ErrorTracker {

--- a/BetterUntisTests/InfoCenterRepositoryTests.swift
+++ b/BetterUntisTests/InfoCenterRepositoryTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import BetterUntis
+
+@MainActor
+final class InfoCenterRepositoryTests: XCTestCase {
+    private var repository: InfoCenterRepository!
+
+    override func setUp() {
+        super.setUp()
+        repository = InfoCenterRepository()
+    }
+
+    func testParseAbsenceRecordHandlesMixedFormats() throws {
+        let payload: [[String: Any]] = [
+            [
+                "id": 77,
+                "date": "2024-03-18",
+                "startTime": "0805",
+                "endTime": "0915",
+                "reason": "Sick",
+                "isExcused": true,
+                "klasse": ["displayName": "1A"],
+                "text": "Flu"
+            ],
+            [
+                "absenceId": "78",
+                "startDate": 20240317,
+                "endDate": 20240318,
+                "from": 1300,
+                "to": 1500,
+                "absenceReason": "Doctor",
+                "class": "1A"
+            ]
+        ]
+        let records = payload.compactMap(repository.parseAbsenceRecord)
+
+        XCTAssertEqual(records.count, 2)
+
+        let first = try XCTUnwrap(records.first)
+        XCTAssertEqual(first.reason, "Sick")
+        XCTAssertEqual(first.className, "1A")
+        XCTAssertEqual(first.excused, true)
+
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents([.hour, .minute], from: first.startDateTime)
+        XCTAssertEqual(components.hour, 8)
+        XCTAssertEqual(components.minute, 5)
+
+        let second = try XCTUnwrap(records.last)
+        XCTAssertEqual(second.reason, "Doctor")
+        XCTAssertNil(second.excused)
+    }
+
+    func testParseHomeworkAttachmentCapturesMetadata() {
+        let attachmentDict: [String: Any] = [
+            "id": "7",
+            "name": "Worksheet",
+            "downloadUrl": "https://example.com/file.pdf",
+            "fileSize": 2048,
+            "mimeType": "application/pdf"
+        ]
+
+        guard let attachment = repository.parseHomeworkAttachment(from: attachmentDict) else {
+            return XCTFail("Expected attachment to parse")
+        }
+
+        XCTAssertEqual(attachment.id, 7)
+        XCTAssertEqual(attachment.name, "Worksheet")
+        XCTAssertEqual(attachment.url, "https://example.com/file.pdf")
+        XCTAssertEqual(attachment.fileSize, 2048)
+        XCTAssertEqual(attachment.mimeType, "application/pdf")
+    }
+
+    func testFormattedTimeStringNormalizesLooseValues() {
+        XCTAssertEqual(repository.formattedTimeString(from: "8:05"), "08:05")
+        XCTAssertEqual(repository.formattedTimeString(from: 915), "09:15")
+        XCTAssertNil(repository.formattedTimeString(from: "--"))
+    }
+
+    func testMessageParsingUsesAllFields() {
+        let data: [[String: Any]] = [
+            [
+                "id": 101,
+                "subject": "Parent Meeting",
+                "text": "Meeting in room A1",
+                "isExpired": false,
+                "attachments": [["id": 1, "name": "Agenda.pdf", "url": "https://example.com/agenda.pdf"]]
+            ],
+            [
+                "id": "102",
+                "title": "School Trip",
+                "message": "Departure at 7:30",
+                "priority": "true",
+                "files": []
+            ]
+        ]
+        let messages = repository.parseMessages(data)
+        XCTAssertEqual(messages.count, 2)
+        let first = messages[0]
+        XCTAssertEqual(first.subject, "Parent Meeting")
+        XCTAssertEqual(first.attachments?.count, 1)
+        XCTAssertEqual(first.attachments?.first?.name, "Agenda.pdf")
+        let second = messages[1]
+        XCTAssertEqual(second.subject, "School Trip")
+        XCTAssertEqual(second.text, "Departure at 7:30")
+        XCTAssertEqual(second.isImportant, true)
+    }
+
+    func testHomeworkParsingNormalizesDates() {
+        let payload: [[String: Any]] = [
+            [
+                "id": 1,
+                "lessonId": 33,
+                "subjectId": 12,
+                "teacherId": 4,
+                "date": "2024-03-19",
+                "dueDate": "2024-03-20",
+                "text": "Worksheet",
+                "remark": "Bring answers",
+                "completed": false,
+                "attachments": [["id": 5, "name": "Task.pdf", "url": "https://example.com/task.pdf"]]
+            ]
+        ]
+        let items = repository.parseHomework(payload)
+        XCTAssertEqual(items.count, 1)
+        let homework = items[0]
+        XCTAssertEqual(homework.text, "Worksheet")
+        XCTAssertEqual(homework.attachments.count, 1)
+        XCTAssertEqual(homework.attachments.first?.name, "Task.pdf")
+    }
+
+    func testExamParsingBuildsAssociatedEntities() {
+        let payload: [[String: Any]] = [
+            [
+                "id": 44,
+                "date": 20240405,
+                "startTime": "0815",
+                "endTime": "0945",
+                "subject": ["displayName": "Mathematics"],
+                "klassen": [["id": 1, "name": "1A"]],
+                "teachers": [["id": 12, "name": "Smith"]],
+                "rooms": [["id": 9, "name": "A1"]],
+                "text": "Chapter 3",
+                "examType": "Test",
+                "name": "Math Test"
+            ]
+        ]
+        let exams = repository.parseExams(payload)
+        XCTAssertEqual(exams.count, 1)
+        let exam = exams[0]
+        XCTAssertEqual(exam.subject, "Mathematics")
+        XCTAssertEqual(exam.classes.first?.name, "1A")
+        XCTAssertEqual(exam.teachers.first?.name, "Smith")
+        XCTAssertEqual(exam.rooms?.first?.name, "A1")
+        XCTAssertEqual(exam.examType, "Test")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ This ensures compatibility with servers from different WebUntis versions dating 
 - **QR Code Implementation**: Full QR code scanning with camera permissions and error handling
 - **Robust Error Handling**: Comprehensive fallback mechanisms for network failures
 - **Memory Management**: Optimized Core Data operations and reduced memory footprint
+- **Offline Master Data Cache**: Timetable refreshes now persist rooms, teachers, subjects, and classes, keeping names available even when offline. Cached entries merge with fresh master data transparently.
+- **Info Center Normalisation**: Messages, homework, exams, and absences are harmonised across legacy payloads, preserving attachments, status flags, and mixed date formats.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- show class, teacher, room, substitutions, homework, and exam details directly in the week timetable cells
- highlight cancellation and exam status chips while keeping supplementary info from double-rendering
- reuse the richer summaries inside the period detail sheet for consistent wording and styling

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2633b5490832290a4ee5240942194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline master data cache for rooms, teachers, subjects, and classes.
  - Info Center overhaul: normalized messages, homework, exams, and a new detailed Absences list.
  - Session expiry handling and automatic token refresh for more reliable sign-ins.
  - New timetable selection sheet and date picker for quicker navigation.

- UI Improvements
  - Compressed timetable header, richer week view with badges, outlines, and detailed period info.

- Bug Fixes
  - More robust timetable parsing and titles, improved cache usage, safer ID parsing, and better 401/session handling.

- Documentation
  - README updated with recent improvements.

- Tests
  - Added comprehensive Info Center parsing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->